### PR TITLE
Add a -download-cop-vrt and --vrt-filename option for local VRT caching

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,5 @@ dependencies:
 - gdal >= 3.4.2
 - numpy >= 1.14.2
 - requests >= 2.20.0
+- shapely >= 2.0
 - pip

--- a/sardem/cli.py
+++ b/sardem/cli.py
@@ -170,12 +170,38 @@ def get_cli_args():
         default="float32",
         help="Output data type (default %(default)s).",
     )
+    parser.add_argument(
+        "--vrt-filename",
+        help=(
+            "Path or URL to a VRT to read tiles from (COP and NISAR sources only).\n"
+            "Useful when the default remote VRT is slow or unreachable: download\n"
+            "the VRT tree locally with `--download-cop-vrt DEST` and pass\n"
+            "DEST/cop_global.vrt here."
+        ),
+    )
+    parser.add_argument(
+        "--download-cop-vrt",
+        metavar="DEST",
+        help=(
+            "Download the COP DEM VRT tree from GitHub into DEST and exit.\n"
+            "After downloading, pass DEST/cop_global.vrt to --vrt-filename on\n"
+            "subsequent runs to avoid the slow remote VRT resolution path."
+        ),
+    )
     return parser.parse_args()
 
 
 def cli():
     args = get_cli_args()
     import sardem.dem
+
+    if args.download_cop_vrt:
+        from sardem import cop_dem
+
+        path = cop_dem.download_local_vrt(args.download_cop_vrt)
+        print("Wrote local COP VRT tree. Use:")
+        print("    sardem ... --vrt-filename {}".format(path))
+        return
 
     if (args.left_lon and args.geojson) or (args.left_lon and args.bbox):
         raise ArgumentError(
@@ -230,4 +256,5 @@ def cli():
         cache_dir=args.cache_dir,
         output_format=args.output_format,
         output_type=args.output_type,
+        vrt_filename=args.vrt_filename,
     )

--- a/sardem/cop_dem.py
+++ b/sardem/cop_dem.py
@@ -252,7 +252,7 @@ def download_local_vrt(dest_dir, branch="master"):
     Examples
     --------
     >>> from sardem.cop_dem import download_local_vrt
-    >>> vrt = download_local_vrt("/data/sardem_vrt")
+    >>> vrt = download_local_vrt("/data/sardem_vrt")  # doctest: +SKIP
     >>> # Then use it via the CLI or library:
     >>> # sardem --bbox ... --vrt-filename /data/sardem_vrt/cop_global.vrt
     """

--- a/sardem/cop_dem.py
+++ b/sardem/cop_dem.py
@@ -223,6 +223,71 @@ def make_cop_vrt(outname="copernicus_GLO_30_dem.vrt"):
     vrt_file = None
 
 
+SARDEM_DATA_TARBALL = (
+    "https://github.com/scottstanie/sardem/archive/refs/heads/{branch}.tar.gz"
+)
+
+
+def download_local_vrt(dest_dir, branch="master"):
+    """Download the COP DEM VRT tree from GitHub for offline use.
+
+    Fetches the ``sardem/data/*.vrt`` files from the sardem repository
+    on GitHub and extracts them into ``dest_dir``. After the download,
+    pass ``{dest_dir}/cop_global.vrt`` to ``--vrt-filename`` (or the
+    ``vrt_filename`` argument of ``download_and_stitch``) to avoid the
+    slow remote VRT resolution path.
+
+    Parameters
+    ----------
+    dest_dir : str
+        Directory to extract the VRT files into. Created if missing.
+    branch : str
+        Repository branch or tag to download from. Defaults to ``"master"``.
+
+    Returns
+    -------
+    str
+        Path to the extracted ``cop_global.vrt``.
+
+    Examples
+    --------
+    >>> from sardem.cop_dem import download_local_vrt
+    >>> vrt = download_local_vrt("/data/sardem_vrt")
+    >>> # Then use it via the CLI or library:
+    >>> # sardem --bbox ... --vrt-filename /data/sardem_vrt/cop_global.vrt
+    """
+    import io
+    import os
+    import tarfile
+    import urllib.request
+
+    os.makedirs(dest_dir, exist_ok=True)
+    url = SARDEM_DATA_TARBALL.format(branch=branch)
+    logger.info("Downloading sardem VRT tree from %s", url)
+    with urllib.request.urlopen(url) as resp:
+        buf = io.BytesIO(resp.read())
+
+    n_extracted = 0
+    with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+        for member in tar.getmembers():
+            parts = member.name.split("/")
+            if (
+                len(parts) == 4
+                and parts[1] == "sardem"
+                and parts[2] == "data"
+                and parts[3].endswith(".vrt")
+            ):
+                src = tar.extractfile(member)
+                assert src is not None
+                with open(os.path.join(dest_dir, parts[3]), "wb") as out:
+                    out.write(src.read())
+                n_extracted += 1
+
+    assert n_extracted > 0, "No VRT files found in tarball; check branch name"
+    logger.info("Extracted %d VRT files into %s", n_extracted, dest_dir)
+    return os.path.join(dest_dir, "cop_global.vrt")
+
+
 def get_tile_list():
     """Get the list of tiles from the Copernicus DEM 30m tile list"""
     logger.info("Getting list of COP tiles from %s", TILE_LIST_URL)

--- a/sardem/dem.py
+++ b/sardem/dem.py
@@ -300,6 +300,7 @@ def main(
     cache_dir=None,
     output_type="float32",
     output_format="GTiff",
+    vrt_filename=None,
 ):
     """Function for entry point to create a DEM with `sardem`
 
@@ -322,6 +323,9 @@ def main(
         cache_dir (str): directory to cache downloaded tiles
         output_type (str): output type for DEM (default = int16)
         output_format (str): output format for copernicus DEM (default = ENVI)
+        vrt_filename (str): Path or URL to a VRT to read tiles from. Applies to
+            the COP and NISAR data sources only. Defaults to the remote VRT
+            built into each module.
     """
     if bbox is None:
         if geojson:
@@ -358,6 +362,7 @@ def main(
             keep_egm=keep_egm,
             xrate=xrate,
             yrate=yrate,
+            vrt_filename=vrt_filename,
             output_format=output_format,
             output_type=output_type,
         )
@@ -399,6 +404,7 @@ def main(
             bbox,
             xrate=xrate,
             yrate=yrate,
+            vrt_filename=vrt_filename,
             output_format=output_format,
             output_type=output_type,
         )


### PR DESCRIPTION
Closes #28

Usage:
```bash
sardem --download-cop-vrt /tmp/sardem_vrt_test
sardem --bbox -156 18.8 -155.7 19.3 --vrt-filename /tmp/sardem_vrt_test/cop_global.vrt
```